### PR TITLE
Allow for LTS update checks in debian

### DIFF
--- a/nopc.sh
+++ b/nopc.sh
@@ -26,6 +26,8 @@
 ###############################################################################
 #
 # VERSION HISTORY
+#  0.5.1	Released 22/12/2020
+#               Allow for DLA LTS Debian update checks
 #  0.5.0	Released 24/03/2017 
 #		Add OpenSuSE checks
 #		Major release after multiple bug fixes from 0.4.7 release
@@ -46,9 +48,9 @@
 #
 ###############################################################################
 
-# Latest version (0.5.0) released on March 24 2017
-# nopc.sh - 0.5.0 (a)
-nopc_version="nopc.sh  0.5.0a"
+# Latest version (0.51) released on December 22 2020
+# nopc.sh - 0.5.1 (a)
+nopc_version="nopc.sh  0.5.1"
 
 #
 # The following OS/Distros are potentially supported:

--- a/nopc.sh
+++ b/nopc.sh
@@ -555,7 +555,7 @@ setDebian(){
 	
 	system=5
 	system_name="Debian"
-	nessus_filematch="debian_DSA"
+	nessus_filematch="debian_D"
 	
 	# Instructions String
 	patch_ins="Run 'dpkg -l|cat > patchlist.txt'"


### PR DESCRIPTION
For LTS releases Debian gives DLA-xxxx update numbers rather than DSA-xxxx.

This update just reduces the plugin filename check from debian_DSA* to debian_D* to ensure those are checked too - maybe side effects but worked in my testing against debian 8.